### PR TITLE
Release v0.4.1

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,60 @@
+name: Deploy Documentation
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'doc/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: doc/package-lock.json
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: doc
+
+      - name: Build with VitePress
+        run: npm run build
+        working-directory: doc
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: doc/.vitepress/dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/doc/guide/backup-restore.md
+++ b/doc/guide/backup-restore.md
@@ -1,6 +1,6 @@
 # Backup & Restore
 
-This guide covers backing up your OpenTracker database and restoring it on a new server.
+This guide covers backing up your Trackarr database and restoring it on a new server.
 
 ## Why Backup?
 
@@ -49,7 +49,7 @@ Store a copy of your `.env` file in a secure location (password manager, encrypt
 
 To restore your database on a new VPS:
 
-**1. Install OpenTracker on the new server**
+**1. Install Trackarr on the new server**
 
 Run the installer as usual:
 

--- a/doc/guide/configuration.md
+++ b/doc/guide/configuration.md
@@ -1,6 +1,6 @@
 # Configuration
 
-OpenTracker is configured primarily through environment variables. This page covers all available options.
+Trackarr is configured primarily through environment variables. This page covers all available options.
 
 ## Environment Variables
 
@@ -8,7 +8,7 @@ OpenTracker is configured primarily through environment variables. This page cov
 
 | Variable                | Description                        | Default       |
 | ----------------------- | ---------------------------------- | ------------- |
-| `NUXT_PUBLIC_SITE_NAME` | Your tracker's display name        | `OpenTracker` |
+| `NUXT_PUBLIC_SITE_NAME` | Your tracker's display name        | `Trackarr` |
 | `NUXT_PUBLIC_SITE_URL`  | Public URL of your tracker         | —             |
 | `NUXT_SESSION_PASSWORD` | Session encryption key (32+ chars) | —             |
 
@@ -66,7 +66,7 @@ Replace `your-domain.com` with your actual tracker domain.
 
 The production compose file includes:
 
-- **app** — Main OpenTracker application
+- **app** — Main Trackarr application
 - **db** — PostgreSQL 16 database
 - **redis** — Redis 7 cache
 - **caddy** — Reverse proxy with automatic HTTPS

--- a/doc/guide/getting-started.md
+++ b/doc/guide/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-This guide will help you get OpenTracker up and running in minutes.
+This guide will help you get Trackarr up and running in minutes.
 
 ## Prerequisites
 
@@ -124,7 +124,7 @@ Open `https://your-domain.com` to access your tracker.
 
 ## Updating
 
-To update your OpenTracker installation to the latest version:
+To update your Trackarr installation to the latest version:
 
 ```bash
 cd /opt/opentracker

--- a/doc/guide/load-testing.md
+++ b/doc/guide/load-testing.md
@@ -1,6 +1,6 @@
 # Load Testing
 
-OpenTracker includes a built-in load testing suite to measure tracker performance under high concurrency.
+Trackarr includes a built-in load testing suite to measure tracker performance under high concurrency.
 
 ## Quick Start
 

--- a/doc/guide/roadmap.md
+++ b/doc/guide/roadmap.md
@@ -1,10 +1,16 @@
 # Roadmap
 
-OpenTracker is actively developed with a focus on performance, security, and usability. Below is our current development roadmap.
+Trackarr is actively developed with a focus on performance, security, and usability. Below is our current development roadmap.
 
-## v0.3.x
+## Released
 
-Features implemented, pending public release:
+### v0.4.0 — Rebranding to Trackarr
+
+- [x] **Project Rebranding** — Trackarr renamed to Trackarr
+- [x] **Repository Migration** — New public repository at `florianjs/trackarr`
+- [x] **Documentation Updates** — All references updated to Trackarr
+
+### v0.3.x — Core Features
 
 - [x] **Custom Branding** — Logo, favicon, site name, colors, font weight
 - [x] **Invitation System** — Private invite codes with per-user limits
@@ -18,7 +24,7 @@ Features implemented, pending public release:
 
 ---
 
-## v0.4.0 — User Features
+## v0.5.0 — User Features
 
 - [ ] **Favorites / Watchlist** — Save torrents to personal list
 - [ ] **Freeleech System** — Global and per-torrent freeleech toggle
@@ -27,7 +33,7 @@ Features implemented, pending public release:
 
 ---
 
-## v0.5.0 — Community
+## v0.6.0 — Community
 
 - [ ] **Torrent Requests** — Request content with bounty system
 - [ ] **Bonus Points** — Reward seeders with exchangeable points
@@ -36,13 +42,13 @@ Features implemented, pending public release:
 
 ---
 
-## v0.6.0 — Plugins System
+## v0.7.0 — Plugins System
 
 - [ ] **Plugin Architecture** — Admin-activatable modules
 
 ---
 
-## v0.7.0 — Public Tracker Mode
+## v0.8.0 — Public Tracker Mode
 
 - [ ] **Public Mode** — Browse and download without account
 - [ ] **Anonymous Announces** — Tracking without passkey
@@ -73,4 +79,4 @@ Features implemented, pending public release:
 ---
 
 > [!NOTE]
-> This roadmap is subject to change based on community feedback and project priorities. Have a feature request? Open an issue on [GitHub](https://github.com/florianjs/opentracker/issues).
+> This roadmap is subject to change based on community feedback and project priorities. Have a feature request? Open an issue on [GitHub](https://github.com/florianjs/trackarr/issues).

--- a/doc/guide/security.md
+++ b/doc/guide/security.md
@@ -1,6 +1,6 @@
 # Security Overview
 
-OpenTracker is built with security as a foundational principle, not an afterthought. This page provides an overview of the security architecture.
+Trackarr is built with security as a foundational principle, not an afterthought. This page provides an overview of the security architecture.
 
 ## Security Layers
 
@@ -14,7 +14,7 @@ OpenTracker is built with security as a foundational principle, not an afterthou
 
 ## Rate Limits
 
-OpenTracker implements distributed rate limiting to prevent abuse:
+Trackarr implements distributed rate limiting to prevent abuse:
 
 | Endpoint | Limit | Action on Abuse |
 |----------|-------|-----------------|

--- a/doc/guide/zero-knowledge-auth.md
+++ b/doc/guide/zero-knowledge-auth.md
@@ -1,6 +1,6 @@
 # Zero-Knowledge Authentication
 
-OpenTracker uses a **Zero-Knowledge** authentication system where the server **never sees or stores your password**. All cryptographic operations happen client-side in your browser.
+Trackarr uses a **Zero-Knowledge** authentication system where the server **never sees or stores your password**. All cryptographic operations happen client-side in your browser.
 
 ## How It Works
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -2,7 +2,7 @@
 layout: home
 
 hero:
-  name: OpenTracker
+  name: Trackarr
   text: Modern Private BitTorrent Tracker
   tagline: High-performance, security-first tracker with Zero-Knowledge Authentication and Panic Mode encryption.
   actions:
@@ -11,7 +11,7 @@ hero:
       link: /guide/getting-started
     - theme: alt
       text: View on GitHub
-      link: https://github.com/florianjs/opentracker
+      link: https://github.com/florianjs/trackarr
     - theme: alt
       text: Live Demo
       link: https://tracker.florianargaud.com/
@@ -31,21 +31,21 @@ features:
     details: Prometheus metrics and Grafana dashboards out of the box. Track peers, announces, and system health in real-time.
 ---
 
-## Why OpenTracker?
+## Why Trackarr?
 
-OpenTracker is designed for communities that value **privacy** and **security** above all else. Unlike traditional trackers that store passwords and personal data in plaintext or with reversible encryption, OpenTracker uses cryptographic proofs that make it mathematically impossible to recover user credentials—even for administrators.
+Trackarr is designed for communities that value **privacy** and **security** above all else. Unlike traditional trackers that store passwords and personal data in plaintext or with reversible encryption, Trackarr uses cryptographic proofs that make it mathematically impossible to recover user credentials—even for administrators.
 
 ### Tech Stack
 
-| Layer | Technology | Purpose |
-|-------|------------|---------|
-| Frontend | Nuxt 4, Vue 3, Tailwind CSS | SSR, Composition API |
-| Backend | Nitro Server Engine | API routes, middleware |
-| Database | PostgreSQL 16 + Drizzle ORM | Data persistence, full-text search |
-| Cache | Redis 7 | Peer lists, sessions, rate limiting |
-| P2P | bittorrent-tracker | HTTP & WebSocket announces |
-| Crypto | Web Crypto API, scrypt, AES-256-GCM | ZKE auth, Panic encryption |
-| Monitor | Prometheus + Grafana | Metrics, dashboards, alerting |
+| Layer    | Technology                          | Purpose                             |
+| -------- | ----------------------------------- | ----------------------------------- |
+| Frontend | Nuxt 4, Vue 3, Tailwind CSS         | SSR, Composition API                |
+| Backend  | Nitro Server Engine                 | API routes, middleware              |
+| Database | PostgreSQL 16 + Drizzle ORM         | Data persistence, full-text search  |
+| Cache    | Redis 7                             | Peer lists, sessions, rate limiting |
+| P2P      | bittorrent-tracker                  | HTTP & WebSocket announces          |
+| Crypto   | Web Crypto API, scrypt, AES-256-GCM | ZKE auth, Panic encryption          |
+| Monitor  | Prometheus + Grafana                | Metrics, dashboards, alerting       |
 
 ---
 

--- a/doc/reference/api.md
+++ b/doc/reference/api.md
@@ -1,6 +1,6 @@
 # API Reference
 
-OpenTracker exposes several API endpoints for tracker operations and frontend interactions.
+Trackarr exposes several API endpoints for tracker operations and frontend interactions.
 
 ## Tracker Endpoints
 
@@ -48,7 +48,7 @@ d5:filesd20:{info_hash}d8:completei10e10:downloadedi50e10:incompletei5eeee
 
 ## WebSocket Announces
 
-OpenTracker supports WebSocket announces for WebTorrent clients:
+Trackarr supports WebSocket announces for WebTorrent clients:
 
 ```javascript
 const ws = new WebSocket('wss://announce.your-domain.com')

--- a/doc/reference/env.md
+++ b/doc/reference/env.md
@@ -1,6 +1,6 @@
 # Environment Variables
 
-Complete reference for all environment variables used by OpenTracker.
+Complete reference for all environment variables used by Trackarr.
 
 ## Required Variables
 
@@ -18,7 +18,7 @@ These must be set for the application to run:
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `NUXT_PUBLIC_SITE_NAME` | Display name of your tracker | `OpenTracker` |
+| `NUXT_PUBLIC_SITE_NAME` | Display name of your tracker | `Trackarr` |
 | `NUXT_PUBLIC_SITE_URL` | Public URL | — |
 | `NUXT_PUBLIC_ANNOUNCE_URL` | Announce URL for torrents | — |
 | `NODE_ENV` | Environment mode | `development` |

--- a/doc/support/professional.md
+++ b/doc/support/professional.md
@@ -1,6 +1,6 @@
 # Professional Support
 
-Need help with your OpenTracker installation? I offer professional services to help you get the most out of your private tracker.
+Need help with your Trackarr installation? I offer professional services to help you get the most out of your private tracker.
 
 ## Services
 
@@ -10,7 +10,7 @@ Don't want to deal with server setup? I'll handle everything:
 
 - VPS provisioning and configuration
 - DNS and SSL setup
-- OpenTracker installation and optimization
+- Trackarr installation and optimization
 - Security hardening
 - Monitoring setup (Prometheus + Grafana)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trackarr",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Release v0.4.1

Add docs workflow, update roadmap, rename to Trackarr in documentation

---

### Changes

[0;34m[INFO][0m No previous tag found, using last 20 commits...
- chore: Rebrand project from OpenTracker to Trackarr, update all documentation, and bump package version.
- feat: publicly publish docs.yml workflow by removing it from the exclusion list
- feat: bump package version to 0.4.0
- refactor: rename project from OpenTracker to Trackarr
- docs: enhance troubleshooting guide with additional solutions and PgBouncer configuration error section
- fix: update .gitignore to include doc/node_modules and improve getting-started guide for production deployment
- fix: update .gitignore to include additional directories and files for better environment management
- chore: bump version to 0.3.2
- feat: add interactive setup script and update environment configuration for tracker URLs
- chore: bump version to 0.3.1
- refactor: Centralize tracker logging with `TRACKER_DEBUG` and remove extraneous `console.log`s across services, while also updating the package version and public publish script.
- docs: Remove specific plugin items from the roadmap.
- refactor: Migrate contributors list generation from GitHub Actions workflow to a local TypeScript script and update roadmap section title.
- docs: restructure roadmap into versioned feature plans and associated schema additions.
- feat: implement custom favicon upload and display functionality
- feat: Introduce local production environment setup, allow HTML in branding fields, and enable serving uploaded files.
- feat: add optional chaining for feature titles and descriptions in settings
- feat: add homepage content section with rich text support and save functionality
- feat: improve code readability by formatting styles and restructuring button classes in Branding component
- feat: add saved state indication and improve save button functionality across multiple components

---

### Checklist
- [ ] Code reviewed
- [ ] Tested locally
- [ ] Documentation updated (if needed)

---

*When this PR is merged, version `v0.4.1` will be automatically tagged.*